### PR TITLE
Fix failing delete user test due to soft deletes

### DIFF
--- a/tests/Feature/DeleteAccountTest.php
+++ b/tests/Feature/DeleteAccountTest.php
@@ -13,9 +13,9 @@ class DeleteAccountTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_user_accounts_can_be_deleted()
+    public function testUserAccountsCanBeDeleted()
     {
-        if (! Features::hasAccountDeletionFeatures()) {
+        if (!Features::hasAccountDeletionFeatures()) {
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 
@@ -25,12 +25,12 @@ class DeleteAccountTest extends TestCase
                         ->set('password', 'password')
                         ->call('deleteUser');
 
-        $this->assertNull($user->fresh());
+        $this->assertNotNull($user->fresh()->deleted_at);
     }
 
-    public function test_correct_password_must_be_provided_before_account_can_be_deleted()
+    public function testCorrectPasswordMustBeProvidedBeforeAccountCanBeDeleted()
     {
-        if (! Features::hasAccountDeletionFeatures()) {
+        if (!Features::hasAccountDeletionFeatures()) {
             return $this->markTestSkipped('Account deletion is not enabled.');
         }
 


### PR DESCRIPTION
Checks the $user->deleted_at is not null instead of the whole $user being null